### PR TITLE
Switch from bundle to bundler in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source :rubygems
 
-gem "bundle"
+gem "bundler"
 gem "rake"
 gem "compass"
 gem "git"


### PR DESCRIPTION
Whilst working on [Libraries.io](https://libraries.io) I noticed that this project depends on the [`bundle`](https://github.com/will/bundle) gem rather than [`bundler`](https://github.com/bundler/bundler/), this pull request fixes the typo.